### PR TITLE
Tool Input Combos fix to avoit instantiating type when it is not required 

### DIFF
--- a/EditorExpanded/Extension/mscorlib/System/Type.cs
+++ b/EditorExpanded/Extension/mscorlib/System/Type.cs
@@ -16,4 +16,31 @@ public static class System__TypeExtensions
 	/// </summary>
 	public static T GetCustomAttribute<T>(this Type type, bool inherit = true) where T : Attribute
 	=> type.GetCustomAttributes<T>(inherit).FirstOrDefault();
+
+    /// <summary>
+    /// Returns if an attribute of type <typeparamref name="T"/> exists and passes it as an output parameter
+    /// </summary>
+    public static bool GetAttribute<T>(this Type type, out T attribute, bool inherit = true) where T : Attribute
+    {
+        attribute = null;
+
+        foreach (var attr in type.GetCustomAttributes(inherit))
+        {
+            if (attr is T)
+            {
+                attribute = attr as T;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+   /// <summary>
+   /// Returns true or false if the type has the attribute
+   /// </summary>
+    public static bool HasAttribute<T>(this Type type, bool inherit = true) where T : Attribute
+	{
+		return GetAttribute<T>(type, out _, inherit);
+	}
 }

--- a/EditorExpanded/Extension/mscorlib/System/Type.cs
+++ b/EditorExpanded/Extension/mscorlib/System/Type.cs
@@ -1,29 +1,19 @@
 ﻿#pragma warning disable RCS1110
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 public static class System__TypeExtensions
 {
-    /// <summary>
-    /// Returns if an attribute of type <typeparamref name="T"/> exists and passes it as an output parameter
-    /// </summary>
-    public static bool GetAttribute<T>(this Type type, out T attribute, bool inherit = true) where T : Attribute
-    {
-        attribute = null;
+	/// <summary>
+	/// Returns attributes of type <typeparamref name="T"/>
+	/// </summary>
+	public static IEnumerable<T> GetCustomAttributes<T>(this Type type, bool inherit = true) where T : Attribute
+	=> type.GetCustomAttributes(inherit).OfType<T>();
 
-        foreach (var attr in type.GetCustomAttributes(inherit))
-        {
-            if (attr is T)
-            {
-                attribute = attr as T;
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    public static bool HasAttribute<T>(this Type type, bool inherit = true) where T : Attribute
-    {
-        return GetAttribute<T>(type, out _, inherit);
-    }
+	/// <summary>
+	/// Returns an attribute of type <typeparamref name="T"/>
+	/// </summary>
+	public static T GetCustomAttribute<T>(this Type type, bool inherit = true) where T : Attribute
+	=> type.GetCustomAttributes<T>(inherit).FirstOrDefault();
 }

--- a/EditorExpanded/Patches/Assembly-CSharp/GUtils/GetExportedTypesOfType.cs
+++ b/EditorExpanded/Patches/Assembly-CSharp/GUtils/GetExportedTypesOfType.cs
@@ -11,14 +11,14 @@ namespace EditorExpanded.Patches
         [HarmonyPostfix]
         internal static void Postfix(Type baseType, ref Type[] __result)
         {
-            List<Type> types = __result.ToList();
+            IEnumerable<Type> types = __result;
 
             if (TypeExportManager.Types.Contains(baseType))
             {
-                types.AddRange(TypeExportManager.GetTypesOfType(baseType));
+                types = types.Concat(TypeExportManager.GetTypesOfType(baseType));
             }
 
-            __result = types.ToArray();
+            __result = types.Distinct().ToArray();
         }
     }
 }

--- a/EditorExpanded/Patches/Assembly-CSharp/ToolInputCombos/Load.cs
+++ b/EditorExpanded/Patches/Assembly-CSharp/ToolInputCombos/Load.cs
@@ -1,77 +1,69 @@
 ﻿using HarmonyLib;
 using LevelEditorTools;
 using System;
+using System.Linq;
 using System.Reflection;
-
-//Hey so this breaks at the Activator.CreateInstance line.
-
-// [Error  : Unity Log] NullReferenceException: Object reference not set to an instance of an object
-// Stack trace:
-// LevelEditorTools.TestAnimationTool..ctor ()
-// System.Reflection.MonoCMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture)
-// Rethrow as TargetInvocationException: Exception has been thrown by the target of an invocation.
-// System.Reflection.MonoCMethod.Invoke (object,System.Reflection.BindingFlags,System.Reflection.Binder,object[],System.Globalization.CultureInfo) <0x0027b>
-// System.Reflection.MonoCMethod.Invoke (System.Reflection.BindingFlags,System.Reflection.Binder,object[],System.Globalization.CultureInfo) <0x00039>
-// System.Reflection.ConstructorInfo.Invoke (object[]) <0x00053>
-// System.Activator.CreateInstance (System.Type,bool) <0x00233>
-// System.Activator.CreateInstance (System.Type) <0x0001e>
-// EditorExpanded.Patches.ToolInputCombos__Load.AddCustomHotkeys (ToolInputCombos&,char) <0x000a2>
-// EditorExpanded.Patches.ToolInputCombos__Load.Postfix (ToolInputCombos&,string&) <0x0008d>
-// (wrapper dynamic-method) ToolInputCombos.DMD<ToolInputCombos..Load> (string) <0x000c3>
-// LevelEditor.set_CurrentInputScheme_ (string) <0x0007c>
-// LevelEditor.Start () <0x001b3>
-
-//WAI
-
+using static System.Reflection.BindingFlags;
 
 namespace EditorExpanded.Patches
 {
-    //Input combos for custom keyboard shortcuts
-    [HarmonyPatch(typeof(ToolInputCombos), "Load")]
-    internal static class ToolInputCombos__Load
-    {
-        [HarmonyPostfix]
-        internal static void Postfix(ref ToolInputCombos __result, ref string fileName)
-        {
-            if (__result is null)
-            {
-                Mod.Log.LogInfo("NULL!??!?!");
-            }
+	//Input combos for custom keyboard shortcuts
+	[HarmonyPatch(typeof(ToolInputCombos), "Load")]
+	internal static class ToolInputCombos__Load
+	{
+		[HarmonyPostfix]
+		internal static void Postfix(ref ToolInputCombos __result, ref string fileName)
+		{
+			if (__result is null)
+			{
+				return;
+			}
 
-            switch (fileName)
-            {
-                case "BlenderToolInputCombos":  // Scheme A
-                    AddCustomHotkeys(ref __result, 'A');
-                    break;
-                case "UnityToolInputCombos":    // Scheme B
-                    AddCustomHotkeys(ref __result, 'B');
-                    break;
-            }
-        }
+			switch (fileName)
+			{
+				case "BlenderToolInputCombos":  // Scheme A
+					AddCustomHotkeys(ref __result, 'A');
+					break;
+				case "UnityToolInputCombos":    // Scheme B
+					AddCustomHotkeys(ref __result, 'B');
+					break;
+			}
+		}
 
-        internal static void AddCustomHotkeys(ref ToolInputCombos __result, char scheme)
-        {
-            Assembly assemblyCS = typeof(G).Assembly;
+		internal static void AddCustomHotkeys(ref ToolInputCombos __result, char scheme)
+		{
+			Assembly assemblyCS = typeof(G).Assembly;
 
-            foreach (Type toolType in TypeExportManager.GetTypesOfType(typeof(LevelEditorTool)))
-            {
-                Mod.Log.LogInfo(toolType.FullName);
-                if (ReferenceEquals(assemblyCS, toolType.Assembly))
-                {
-                    Mod.Log.LogWarning("Ignoring");
-                    continue;
-                }
+			bool filterType(Type type)
+			{
+				return !ReferenceEquals(assemblyCS, type.Assembly)
+					&& type.GetCustomAttribute<EditorToolAttribute>(false) is object;
+			}
 
-                LevelEditorTool instance = Activator.CreateInstance(toolType) as LevelEditorTool;
+			foreach (Type toolType in TypeExportManager.GetTypesOfType(typeof(LevelEditorTool)).Where(filterType))
+			{
+				if (GetToolInfo(toolType) is ToolInfo info && toolType.GetCustomAttribute<EditorToolAttribute>(false) is KeyboardShortcutAttribute attribute)
+				{
+					__result.Add(attribute.Get(scheme).ToString(), info.Name_);
+				}
+			}
+		}
 
-                if (toolType.HasAttribute<EditorToolAttribute>() && toolType.GetAttribute(out KeyboardShortcutAttribute attribute, false))
-                {
-                    if (instance.Info_ is null)
-                        Mod.Log.LogInfo(toolType.FullName + " Info is null");
+		internal static ToolInfo GetToolInfo(Type toolType)
+		{
+			if (toolType is null)
+			{
+				return null;
+			}
 
-                    __result.Add(attribute.Get(scheme).ToString(), instance.Info_.Name_);
-                }
-            }
-        }
-    }
+			const BindingFlags bindingAttr = Static | NonPublic;
+			if (toolType.GetField("info_", bindingAttr) is FieldInfo info_)
+			{
+				return info_.GetValue(null) as ToolInfo;
+			}
+
+			LevelEditorTool instance = Activator.CreateInstance(toolType) as LevelEditorTool;
+			return instance?.Info_;
+		}
+	}
 }

--- a/EditorExpanded/Patches/Assembly-CSharp/ToolInputCombos/Load.cs
+++ b/EditorExpanded/Patches/Assembly-CSharp/ToolInputCombos/Load.cs
@@ -42,7 +42,7 @@ namespace EditorExpanded.Patches
 
 			foreach (Type toolType in TypeExportManager.GetTypesOfType(typeof(LevelEditorTool)).Where(filterType))
 			{
-				if (GetToolInfo(toolType) is ToolInfo info && toolType.GetCustomAttribute<EditorToolAttribute>(false) is KeyboardShortcutAttribute attribute)
+				if (GetToolInfo(toolType) is ToolInfo info && toolType.GetCustomAttribute<KeyboardShortcutAttribute>(false) is KeyboardShortcutAttribute attribute)
 				{
 					__result.Add(attribute.Get(scheme).ToString(), info.Name_);
 				}

--- a/EditorExpanded/Plugin.cs
+++ b/EditorExpanded/Plugin.cs
@@ -2,6 +2,7 @@
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
+using LevelEditorTools;
 using System;
 using System.Linq;
 
@@ -82,6 +83,7 @@ namespace EditorExpanded
             TrackNodeColors = TrackNodeColors.FromSettings("SplineColors.json");
             TrackNodeColors.OnFileReloaded += ReloadTrackNodeColors;
 
+            RegisterExportedTypes();
 
             //Config Setup
             DevFolderEnabled = Config.Bind<bool>("General",
@@ -188,6 +190,12 @@ namespace EditorExpanded
             SettingChangedEventArgs settingChangedEventArgs = e as SettingChangedEventArgs;
 
             if (settingChangedEventArgs == null) return;
+        }
+
+        private void RegisterExportedTypes()
+        {
+            TypeExportManager.Register<ISerializable>();
+            TypeExportManager.Register<LevelEditorTool>((type) => type.HasAttribute<EditorToolAttribute>());
         }
 
         private void ReloadTrackNodeColors(object sender, EventArgs e)


### PR DESCRIPTION
This PR modifies the ToolInputCombos.Load postfix patch to use the static field `ToolInfo info_` of the declared editor tool type if it is present.
Otherwise the type gets instantiated in order to read the instance property `Info_` instead
This pull request also contains refactorings on a few other files